### PR TITLE
不要なダブルクオーテーションを削除

### DIFF
--- a/pinbot_hoc/__main__.py
+++ b/pinbot_hoc/__main__.py
@@ -85,7 +85,7 @@ async def on_raw_reaction_add(payload: discord.RawReactionActionEvent):
     if added_emoji == '👎' and is_bad_message and message.pinned:
         await channel.send(embed=discord.Embed(
             title='一定数の低評価が付いたため、ピン留めを解除しました',
-            description=f'["ここをクリックすると対象のメッセージに移動できます"]({message.jump_url})'))
+            description=f'[ここをクリックすると対象のメッセージに移動できます]({message.jump_url})'))
         await message.unpin()
 
     if added_emoji == '📌' and not message.pinned and not is_bad_message:
@@ -119,7 +119,7 @@ async def on_raw_reaction_remove(payload: discord.RawReactionActionEvent):
     if message.pinned:
         await channel.send(embed=discord.Embed(
             title='ピン留めを解除しました',
-            description=f'["ここをクリックすると対象のメッセージに移動できます"]({message.jump_url})'))
+            description=f'[ここをクリックすると対象のメッセージに移動できます]({message.jump_url})'))
         await message.unpin()
 
 """


### PR DESCRIPTION
ピン留め解除時のメッセージに不要なダブルクオーテーションが付いていたので取り除きました。